### PR TITLE
Make local setup docs more explicit & apply DRY on http client class

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ convoy = Convoy({"api_key":"your_api_key", "project_id": "your_project_id"})
 ```
 The SDK also supports authenticating via Basic Auth by defining your username and password.
 
-In the event you're using a self-hosted convoy instance, you can define the `uri` as part of what is passed into the convoy's constructor.
+In the event you're using a self-hosted convoy instance, `uri` should contain the `hostname:port` combination (see example below).
 
 ```python
-convoy = Convoy({ "api_key": 'your_api_key', "uri": 'self-hosted-instance', "project_id": "your_project_id"})
+convoy = Convoy({ "api_key": 'your_api_key', "uri": 'http://localhost:5005', "project_id": "your_project_id"})
 ```
 
 ## Usage

--- a/convoy/client/client.py
+++ b/convoy/client/client.py
@@ -24,37 +24,29 @@ class Client():
         if config.uri == "":
             self.base_uri = f"https://dashboard.getconvoy.io/api/v1/projects/{config.project_id}"
         else:
-            self.base_uri = config.uri
+            self.base_uri = f"{config.uri}/api/v1/projects/{config.project_id}"
 
         self.headers = {"Authorization": self.get_authorization(), "Content-Type": "application/json; charset=utf-8"}
 
-    def http_get(self, path, query):
+    def _http_request(self, verb, path, query, data=None):
         try:
-            response = requests.get(self.build_path(path), headers=self.headers, params=query)
+            method = getattr(requests, verb)
+            response = method(self.build_path(path), headers=self.headers, params=query, data=data)
             return response.json(), response.status_code
         except BaseException as e:
-            return response_helper(e) 
+            response_helper(e)
+
+    def http_get(self, path, query):
+        return self._http_request('get', path, query)
 
     def http_post(self, path, query, data):
-        try:
-            response = requests.post(self.build_path(path), data=json.dumps(data), headers=self.headers, params=query)
-            return response.json(), response.status_code
-        except BaseException as e:
-            return response_helper(e) 
+        return self._http_request('post', path, query, json.dumps(data))
 
     def http_put(self, path, query, data):
-        try:
-            response = requests.put(self.build_path(path), data=json.dumps(data), headers=self.headers, params=query)
-            return response.json(), response.status_code
-        except BaseException as e:
-            return response_helper(e) 
+        return self._http_request('put', path, query, json.dumps(data))
 
     def http_delete(self, path, query, data):
-        try:
-            response = requests.delete(self.build_path(path), data=json.dumps(data), headers=self.headers, params=query)
-            return response.json(), response.status_code
-        except BaseException as e:
-            return response_helper(e) 
+        return self._http_request('delete', path, query, json.dumps(data))
 
     def get_base_url(self):
         return self.base_uri


### PR DESCRIPTION
Hi,

The changes I'm proposing are in the spirit of enhancing the onboarding process when starting out with the library. 
It wasn't clear for me what the `uri` should have contained initially, I assumed a combination of `hostname:port` would suffice but apparently I was wrong as I kept getting some HTTP errors. 

I propose changing slightly the initialization of the `base_uri` to abstract away the need to pass the custom routes in the configuration `uri`. In my opinion, it should be invisible to the user.  

Also, after digging into the code, I stumbled upon the `Client` class code and I felt I could make it simpler by remove the `try/except` snippet repetitions (DRY principle). 

Also, by the looks of it, it doesn't look like there's an extensive test suite for this package, that's why my PR doesn't include any update in that regards. 

Thanks! Looking forward to the feedback. 